### PR TITLE
Treat AmazonDigital as Reliable

### DIFF
--- a/sacad/sources/amazondigital.py
+++ b/sacad/sources/amazondigital.py
@@ -13,7 +13,7 @@ from sacad.sources.base import CoverSource
 class AmazonDigitalCoverSourceResult(CoverSourceResult):
 
   def __init__(self, *args, **kwargs):
-    super().__init__(*args, source_quality=CoverSourceQuality.NORMAL, **kwargs)
+    super().__init__(*args, source_quality=CoverSourceQuality.REFERENCE, **kwargs)
 
 
 class AmazonDigitalCoverSource(CoverSource):


### PR DESCRIPTION
Current decision prevents below commands from matching HQ covers.

`sacad -t 100 "Alice Sara Ott" "Pictures" 1600 cover.jpg`
`sacad -t 100 "Alice Sara Ott" "Chopin: Waltzes" 1600 cover.jpg`
`sacad -t 100 "Vladimir Horowitz" "The Last Romantic" 1600 cover.jpg`

I did my best searching a false positive case from `AmazonDigital` source with no success. Please correct me if that's not the case.