### PR TITLE
Support downloading of covers for files with APE tags

### DIFF
--- a/sacad/recurse.py
+++ b/sacad/recurse.py
@@ -131,7 +131,7 @@ def get_file_metadata(audio_filepath):
     elif isinstance(mf.tags, mutagen.mp4.MP4Tags):
         has_embedded_cover = "covr" in mf
     else:
-        return
+        has_embedded_cover = False
 
     return Metadata(artist, album, has_embedded_cover)
 


### PR DESCRIPTION
This fixes the Problem I have in #56

I am not sure if this fix does quite the right thing, but it solves the problem I have.